### PR TITLE
Fix hang and weechat package install

### DIFF
--- a/packer/weechat/weechat-LATEST/bootstrap.sh
+++ b/packer/weechat/weechat-LATEST/bootstrap.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 
 main() {
- echo "install packages"
- export DEBIAN_FRONTEND=noninteractive
- sudo apt-get update
- # Install weechat hangs due to libssl update causing an interactive prompt
- # https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1833013
- # sudo apt-get install -y weechat-curses weechat-plugins
+  echo "install packages"
+  sudo apt-get update
+  # Install weechat hangs due to libssl update causing an interactive prompt
+  # https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1833013
+  # use work around from https://github.com/hashicorp/vagrant/issues/10914
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y weechat-curses weechat-plugins
 }
 
 main

--- a/packer/weechat/weechat-LATEST/template.json
+++ b/packer/weechat/weechat-LATEST/template.json
@@ -49,7 +49,7 @@
     "InstanceType": "t2.nano",
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
-    "SourceImage": "ami-0a313d6098716f372",
+    "SourceImage": "ami-0cfee17793b08a293",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }

--- a/packer/weechat/weechat-v1.0.0/template.json
+++ b/packer/weechat/weechat-v1.0.0/template.json
@@ -43,7 +43,7 @@
     "InstanceType": "t2.nano",
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
-    "SourceImage": "ami-0a313d6098716f372",
+    "SourceImage": "ami-0cfee17793b08a293",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"
   }


### PR DESCRIPTION
* use work around from https://github.com/hashicorp/vagrant/issues/10914
  for libssl install hanging issue
* ubuntu 18.04 can't find weechat packages so change to use
  ubuntu 16.04 AMI instead.