### PR TITLE
Change to private AMIs

### DIFF
--- a/packer/sagebio/sagebio-base-aws-linux2-LATEST/template.json
+++ b/packer/sagebio/sagebio-base-aws-linux2-LATEST/template.json
@@ -1,8 +1,8 @@
 {
   "builders": [
     {
-      "ami_groups": "{{user `AmiGroups`}}",
       "ami_name": "{{user `ImageName`}}",
+      "ami_users": "{{user `AmiUsers`}}",
       "force_delete_snapshot": "true",
       "instance_type": "{{user `InstanceType`}}",
       "launch_block_device_mappings": [
@@ -15,6 +15,7 @@
       ],
       "profile": "{{user `AwsProfile`}}",
       "region": "{{user `AwsRegion`}}",
+      "snapshot_users": "{{user `SnapshotUsers`}}",
       "source_ami": "{{user `SourceImage`}}",
       "ssh_username": "{{user `SshUsername`}}",
       "tags": {
@@ -47,12 +48,13 @@
     }
   ],
   "variables": {
-    "AmiGroups": "all",
+    "AmiUsers": "563295687221,055273631518,804034162148",
     "Department": "Platform",
     "ImageName": "sagebio-base-aws-linux2-LATEST",
     "InstanceType": "t2.nano",
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
+    "SnapshotUsers": "563295687221,055273631518,804034162148",
     "SourceImage": "ami-0b69ea66ff7391e80",
     "SshUsername": "ec2-user",
     "VolumeSize": "8"

--- a/packer/sagebio/sagebio-base-ubuntu-bionic-LATEST/template.json
+++ b/packer/sagebio/sagebio-base-ubuntu-bionic-LATEST/template.json
@@ -1,8 +1,8 @@
 {
   "builders": [
     {
-      "ami_groups": "{{user `AmiGroups`}}",
       "ami_name": "{{user `ImageName`}}",
+      "ami_users": "{{user `AmiUsers`}}",
       "force_delete_snapshot": "true",
       "instance_type": "{{user `InstanceType`}}",
       "launch_block_device_mappings": [
@@ -15,6 +15,7 @@
       ],
       "profile": "{{user `AwsProfile`}}",
       "region": "{{user `AwsRegion`}}",
+      "snapshot_users": "{{user `SnapshotUsers`}}",
       "source_ami": "{{user `SourceImage`}}",
       "ssh_username": "{{user `SshUsername`}}",
       "tags": {
@@ -47,12 +48,13 @@
     }
   ],
   "variables": {
-    "AmiGroups": "all",
+    "AmiUsers": "563295687221,055273631518,804034162148",
     "Department": "Platform",
     "ImageName": "sagebio-base-ubuntu-bionic-LATEST",
-    "InstanceType": "t2.micro",
+    "InstanceType": "t2.nano",
     "OwnerEmail": "khai.do@sagebase.org",
     "Project": "Infrastructure",
+    "SnapshotUsers": "563295687221,055273631518,804034162148",
     "SourceImage": "ami-0a313d6098716f372",
     "SshUsername": "ubuntu",
     "VolumeSize": "8"


### PR DESCRIPTION
There are two problems with making our jumpcloud AMIs public:

* Installation of jumpcloud agents requires a "CONNECT_KEY"[1] which
gets saved to a file on the system. That means anyone who provisions an
instance from our AMI will have access to the CONNECT_KEY and we
don't want that.

* Instances provisioned from our AMI will get automatically
associated with our jumpcloud SAS account.  We don't want instances
to be associated with our jumpcloud account unless they are
provisioned by Sage.

We change it to deploy a private AMI that is only share to sage accounts
(sandbox, scicomp, and itsandbox)

[1] https://support.jumpcloud.com/support/s/article/agent-deployment1#linux